### PR TITLE
ascii: remove deprecated AsciiExt; fix 0x1fffff cast for release

### DIFF
--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -96,5 +96,5 @@ fn bad_ascii() {
 
     // `bogus` now holds ill-formed UTF-8. Parsing its first character
     // produces a `char` that is not a valid Unicode code point.
-    assert_eq!(bogus.chars().next().unwrap() as u32, u32::from(0x1fffff).unwrap());
+    assert_eq!(bogus.chars().next().unwrap() as u32, u32::try_from(0x1fffff).unwrap());
 }

--- a/ascii/src/lib.rs
+++ b/ascii/src/lib.rs
@@ -1,6 +1,4 @@
 mod my_ascii {
-    use std::ascii::AsciiExt; // for u8::is_ascii
-
     /// An ASCII-encoded string.
     #[derive(Debug, Eq, PartialEq)]
     pub struct Ascii(
@@ -82,6 +80,7 @@ fn good_ascii() {
 #[test]
 fn bad_ascii() {
     use self::my_ascii::Ascii;
+    use std::convert::TryFrom;
 
     // Imagine that this vector is the result of some complicated process
     // that we expected to produce ASCII. Something went wrong!
@@ -97,5 +96,5 @@ fn bad_ascii() {
 
     // `bogus` now holds ill-formed UTF-8. Parsing its first character
     // produces a `char` that is not a valid Unicode code point.
-    assert_eq!(bogus.chars().next().unwrap() as u32, 0x1fffff);
+    assert_eq!(bogus.chars().next().unwrap() as u32, u32::from(0x1fffff).unwrap());
 }


### PR DESCRIPTION
@jimblandy Hi,
- [AsciiExt](https://doc.rust-lang.org/std/ascii/trait.AsciiExt.html) is deprecated since `1.26.0`
- also under `release` mode, `0x1fffff` is treated as i32, and the test fails