### PR TITLE
ch21: libgit2-safe; replace deprecated const ONCE_INIT

### DIFF
--- a/libgit2-rs-safe/src/git/mod.rs
+++ b/libgit2-rs-safe/src/git/mod.rs
@@ -75,7 +75,7 @@ use std;
 use libc;
 
 fn ensure_initialized() {
-    static ONCE: std::sync::Once = std::sync::ONCE_INIT;
+    static ONCE: std::sync::Once = std::sync::Once::new();
     ONCE.call_once(|| {
         unsafe {
             check(raw::git_libgit2_init())


### PR DESCRIPTION
@jimblandy use of `std::sync::Once::new`, due to warning

```
warning: use of deprecated constant `std::sync::ONCE_INIT`: the `new` function is now preferred
  --> src/git/mod.rs:78:36
   |
78 |     static ONCE: std::sync::Once = std::sync::ONCE_INIT;
   |                                    ^^^^^^^^^^^^^^^^^^^^ help: replace the use of the deprecated constant: `Once::new()`
```