### PR TITLE
fix: Update README.md to correct "Foreign Functions" chapter number to 23 (Issue #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ terms of the MIT license. See [LICENSE-MIT](LICENSE-MIT) for details.
   Pointers” section to illustrate pointer arithmetic and `std::ptr::read` and
   `std::ptr::write`.
 
-## Chapter 22: Foreign Functions
+## Chapter 23: Foreign Functions
 
 - The `libgit2-rs` and `libgit2-rs-safe` directories contain the two versions of
   the program that uses Rust's foreign function interface to call functions from


### PR DESCRIPTION
# Pull Request Description

## Summary

This pull request addresses a documentation error identified in Issue #20. Specifically, it aims to correct the heading "Chapter 22: Foreign Functions" in the `README.md` file to properly reflect the correct chapter number as per the second edition of the book. The correct heading should read "Chapter 23: Foreign Functions".

## Background

In reviewing the documentation for the book, it was noted that the "Foreign Functions" chapter was mistakenly listed as Chapter 22. This inconsistency arises from the fact that in the first edition of the book, there was no chapter dedicated to "Foreign Functions." However, with the release of the second edition, this topic is now included as Chapter 23.

## Changes Made

- Updated the heading in the `README.md` file from:
  ```
  Chapter 22: Foreign Functions
  ```
  to:
  ```
  Chapter 23: Foreign Functions
  ```

## Rationale

Correcting this heading is essential to ensure that users and readers of the documentation have accurate information regarding the structure of the book, especially when transitioning from the first edition to the second edition. This small but significant change will help in avoiding confusion among readers regarding the chapters and their respective contents.

## Additional Notes

This change is purely a documentation update and does not affect any code or functionality within the project. No additional tests are necessary as this change pertains solely to text correction.

## Next Steps

If approved, this pull request will ensure that the documentation reflects the correct chaptering of the book, improving the overall clarity for users. Please review the changes and merge at your earliest convenience.

Thank you for your attention to this matter.